### PR TITLE
Adjust schedule

### DIFF
--- a/app/code/community/Technooze/Tproductschedule/etc/config.xml
+++ b/app/code/community/Technooze/Tproductschedule/etc/config.xml
@@ -45,8 +45,8 @@
         <jobs>
             <technooze_tproductschedule_process_schedule>
                 <schedule>
-                    <!-- Schedule for every 5 minutes -->
-                    <cron_expr>*/5 * * * *</cron_expr>
+                    <!-- Schedule for midnight (daily) -->
+                    <cron_expr>0 0 * * *</cron_expr>
                 </schedule>
                 <run>
                     <model>technooze_tproductschedule/observer::cronProcessScheduledProducts</model>


### PR DESCRIPTION
Greetings Damu, hope all is well.

Since the schedule in admin can only be set by date (thus implied 00:00:00 in time) I see no point in running the schedule every 5 minutes.
Once a day, at midnight, would do the job just as well, and imply less resources
